### PR TITLE
feat: add data routes and db methods

### DIFF
--- a/api/routes/get/channels.go
+++ b/api/routes/get/channels.go
@@ -1,0 +1,57 @@
+// Package get contains routes for http.MethodGet requests.
+package get
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/Potat-Industries/potat-api/api"
+	"github.com/Potat-Industries/potat-api/api/middleware"
+	"github.com/Potat-Industries/potat-api/common"
+	"github.com/Potat-Industries/potat-api/common/db"
+	"github.com/Potat-Industries/potat-api/common/logger"
+)
+
+// ChannelsResponse is the response type for the GET /channels endpoint.
+type ChannelsResponse = common.GenericResponse[common.ChannelListItem]
+
+func init() {
+	api.SetRoute(api.Route{
+		Path:    "/channels",
+		Method:  http.MethodGet,
+		Handler: getChannelsHandler,
+		UseAuth: false,
+	})
+}
+
+func getChannelsHandler(writer http.ResponseWriter, request *http.Request) {
+	start := time.Now()
+
+	postgres, ok := request.Context().Value(middleware.PostgresKey).(*db.PostgresClient)
+	if !ok {
+		logger.Error.Println("Postgres client not found in context")
+		api.GenericResponse(writer, http.StatusInternalServerError, ChannelsResponse{
+			Errors: &[]common.ErrorMessage{{Message: "Internal Server Error"}},
+		}, start)
+
+		return
+	}
+
+	channels, err := postgres.GetAllChannels(request.Context())
+	if err != nil {
+		logger.Error.Printf("Error fetching channels: %v", err)
+		api.GenericResponse(writer, http.StatusInternalServerError, ChannelsResponse{
+			Errors: &[]common.ErrorMessage{{Message: "Failed to fetch channels"}},
+		}, start)
+
+		return
+	}
+
+	if channels == nil {
+		channels = []common.ChannelListItem{}
+	}
+
+	api.GenericResponse(writer, http.StatusOK, ChannelsResponse{
+		Data: &channels,
+	}, start)
+}

--- a/api/routes/get/command_settings.go
+++ b/api/routes/get/command_settings.go
@@ -1,0 +1,124 @@
+// Package get contains routes for http.MethodGet requests.
+package get
+
+import (
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/Potat-Industries/potat-api/api"
+	"github.com/Potat-Industries/potat-api/api/middleware"
+	"github.com/Potat-Industries/potat-api/common"
+	"github.com/Potat-Industries/potat-api/common/db"
+	"github.com/Potat-Industries/potat-api/common/logger"
+	"github.com/gorilla/mux"
+)
+
+// CommandSettingsResponse is the response type for GET /channel/command-settings.
+type CommandSettingsResponse = common.GenericResponse[common.CommandSettings]
+
+func init() {
+	api.SetRoute(api.Route{
+		Path:    "/channel/command-settings",
+		Method:  http.MethodGet,
+		Handler: getCommandSettingsHandler,
+		UseAuth: true,
+	})
+}
+
+// isChannelAuthorized returns true if the user is admin, the broadcaster, or a channel ambassador.
+func isChannelAuthorized(
+	request *http.Request,
+	user *common.User,
+	channelID string,
+	postgres *db.PostgresClient,
+) bool {
+	if int(common.ADMIN) <= user.Level {
+		return true
+	}
+
+	twitchID := getTwitchPlatformID(user)
+
+	if twitchID == channelID {
+		return true
+	}
+
+	ambassadors, err := postgres.GetChannelAmbassadors(request.Context(), channelID, common.TWITCH)
+	if err != nil {
+		return false
+	}
+
+	return slices.Contains(ambassadors, twitchID)
+}
+
+// resolveChannelID returns the channel ID from ?id= or defaults to the authenticated user's Twitch ID.
+func resolveChannelID(request *http.Request, user *common.User) string {
+	if id := request.URL.Query().Get("id"); id != "" {
+		return id
+	}
+
+	// Check path variable as fallback (e.g. /channel/:id/...)
+	if id := mux.Vars(request)["id"]; id != "" {
+		return id
+	}
+
+	return getTwitchPlatformID(user)
+}
+
+func getCommandSettingsHandler(writer http.ResponseWriter, request *http.Request) {
+	start := time.Now()
+
+	user, ok := request.Context().Value(middleware.AuthedUser).(*common.User)
+	if !ok || user == nil {
+		api.GenericResponse(writer, http.StatusUnauthorized, CommandSettingsResponse{
+			Errors: &[]common.ErrorMessage{{Message: "Unauthorized"}},
+		}, start)
+
+		return
+	}
+
+	postgres, pgOK := request.Context().Value(middleware.PostgresKey).(*db.PostgresClient)
+	if !pgOK {
+		logger.Error.Println("Postgres client not found in context")
+		api.GenericResponse(writer, http.StatusInternalServerError, CommandSettingsResponse{
+			Errors: &[]common.ErrorMessage{{Message: "Internal Server Error"}},
+		}, start)
+
+		return
+	}
+
+	channelID := resolveChannelID(request, user)
+	if channelID == "" {
+		api.GenericResponse(writer, http.StatusBadRequest, CommandSettingsResponse{
+			Errors: &[]common.ErrorMessage{{Message: "channel id is required"}},
+		}, start)
+
+		return
+	}
+
+	if !isChannelAuthorized(request, user, channelID, postgres) {
+		api.GenericResponse(writer, http.StatusForbidden, CommandSettingsResponse{
+			Errors: &[]common.ErrorMessage{{Message: "Forbidden"}},
+		}, start)
+
+		return
+	}
+
+	settings, err := postgres.GetCommandSettings(request.Context(), channelID)
+	if err != nil {
+		logger.Error.Printf("Error fetching command settings: %v", err)
+		api.GenericResponse(writer, http.StatusInternalServerError, CommandSettingsResponse{
+			Errors: &[]common.ErrorMessage{{Message: "Failed to fetch command settings"}},
+		}, start)
+
+		return
+	}
+
+	if settings == nil {
+		settings = []common.CommandSettings{}
+	}
+
+	api.GenericResponse(writer, http.StatusOK, CommandSettingsResponse{
+		Data: &settings,
+	}, start)
+}

--- a/api/routes/get/emotes.go
+++ b/api/routes/get/emotes.go
@@ -1,0 +1,263 @@
+// Package get contains routes for http.MethodGet requests.
+package get
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Potat-Industries/potat-api/api"
+	"github.com/Potat-Industries/potat-api/api/middleware"
+	"github.com/Potat-Industries/potat-api/common"
+	"github.com/Potat-Industries/potat-api/common/db"
+	"github.com/Potat-Industries/potat-api/common/logger"
+	"github.com/gorilla/mux"
+)
+
+const (
+	defaultEmoteLimit = 100
+	maxEmoteLimit     = 300
+)
+
+func init() {
+	api.SetRoute(api.Route{
+		Path:    "/emotes/stats",
+		Method:  http.MethodGet,
+		Handler: getEmoteStats,
+		UseAuth: false,
+	})
+	api.SetRoute(api.Route{
+		Path:    "/emotes/history/{login}",
+		Method:  http.MethodGet,
+		Handler: getEmoteHistory,
+		UseAuth: false,
+	})
+}
+
+// periodToHours converts a period string to a number of hours. 0 means no time filter.
+func periodToHours(period string) int {
+	switch strings.ToLower(period) {
+	case "hour":
+		return 1
+	case "day":
+		return 24
+	case "week":
+		return 168
+	case "month":
+		return 720
+	default:
+		return 0
+	}
+}
+
+// normaliseProvider maps user-facing provider names to Clickhouse enum values.
+func normaliseProvider(provider string) []string {
+	switch strings.ToUpper(provider) {
+	case "7TV", "STV":
+		return []string{"STV"}
+	case "FFZ":
+		return []string{"FFZ"}
+	case "BTTV":
+		return []string{"BTTV"}
+	case "TWITCH":
+		return []string{"TWITCH"}
+	case "EMOJI":
+		return []string{"EMOJI"}
+	case "ALL", "":
+		return []string{}
+	default:
+		return []string{"STV"}
+	}
+}
+
+func encodeCursor(offset int) string {
+	return base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+}
+
+func decodeCursor(cursor string) (int, error) {
+	b, err := base64.StdEncoding.DecodeString(cursor)
+	if err != nil {
+		return 0, err
+	}
+
+	return strconv.Atoi(string(b))
+}
+
+func getEmoteStats(writer http.ResponseWriter, request *http.Request) { //nolint:cyclop
+	start := time.Now()
+
+	clickhouse, ok := request.Context().Value(middleware.ClickhouseKey).(*db.ClickhouseClient)
+	if !ok {
+		logger.Error.Println("Clickhouse client not found in context")
+		writeEmoteError(writer, http.StatusInternalServerError, start)
+
+		return
+	}
+
+	query := request.URL.Query()
+
+	channelID := query.Get("id")
+	login := query.Get("login")
+
+	// If login was provided, resolve to a channel ID via Postgres
+	if channelID == "" && login != "" {
+		postgres, pgOK := request.Context().Value(middleware.PostgresKey).(*db.PostgresClient)
+		if !pgOK {
+			writeEmoteError(writer, http.StatusInternalServerError, start)
+
+			return
+		}
+
+		ch, err := postgres.GetChannelByName(request.Context(), login, common.TWITCH)
+		if err != nil {
+			writeEmoteError(writer, http.StatusNotFound, start)
+
+			return
+		}
+
+		channelID = ch.ChannelID
+	}
+
+	if channelID == "" {
+		writeEmoteError(writer, http.StatusBadRequest, start)
+
+		return
+	}
+
+	limit := defaultEmoteLimit
+	if v := query.Get("limit"); v == "" {
+		if v = query.Get("first"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= maxEmoteLimit {
+				limit = n
+			}
+		}
+	} else if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= maxEmoteLimit {
+		limit = n
+	}
+
+	offset := 0
+	if cursor := query.Get("after"); cursor != "" {
+		if o, err := decodeCursor(cursor); err == nil {
+			offset = o
+		}
+	}
+
+	opts := db.EmoteStatsOptions{
+		ChannelID:   channelID,
+		PeriodHours: periodToHours(query.Get("period")),
+		Providers:   normaliseProvider(query.Get("provider")),
+		Order:       query.Get("order"),
+		Limit:       limit + 1, // fetch one extra to determine hasNextPage
+		Offset:      offset,
+	}
+
+	stats, err := clickhouse.GetEmoteStats(request.Context(), opts)
+	if err != nil {
+		logger.Error.Printf("Error fetching emote stats: %v", err)
+		writeEmoteError(writer, http.StatusInternalServerError, start)
+
+		return
+	}
+
+	if stats == nil {
+		stats = []common.EmoteStat{}
+	}
+
+	hasNextPage := len(stats) > limit
+	if hasNextPage {
+		stats = stats[:limit]
+	}
+
+	var nextCursor string
+	if hasNextPage {
+		nextCursor = encodeCursor(offset + limit)
+	}
+
+	elapsed := time.Since(start).Seconds()
+	api.GenericResponse(writer, http.StatusOK, common.EmoteStatsResponse{
+		Data: &stats,
+		Pagination: common.PageInfo{
+			HasNextPage: hasNextPage,
+			Cursor:      nextCursor,
+		},
+		StatusCode: http.StatusOK,
+		Duration:   elapsed,
+	}, start)
+}
+
+func getEmoteHistory(writer http.ResponseWriter, request *http.Request) { //nolint:cyclop
+	start := time.Now()
+
+	login := mux.Vars(request)["login"]
+	if login == "" {
+		api.GenericResponse(writer, http.StatusBadRequest, common.GenericResponse[common.EmoteHistoryEntry]{
+			Errors: &[]common.ErrorMessage{{Message: "login is required"}},
+		}, start)
+
+		return
+	}
+
+	clickhouse, ok := request.Context().Value(middleware.ClickhouseKey).(*db.ClickhouseClient)
+	if !ok {
+		logger.Error.Println("Clickhouse client not found in context")
+		api.GenericResponse(writer, http.StatusInternalServerError, common.GenericResponse[common.EmoteHistoryEntry]{
+			Errors: &[]common.ErrorMessage{{Message: "Internal Server Error"}},
+		}, start)
+
+		return
+	}
+
+	// Resolve login → channel ID
+	postgres, pgOK := request.Context().Value(middleware.PostgresKey).(*db.PostgresClient)
+	if !pgOK {
+		api.GenericResponse(writer, http.StatusInternalServerError, common.GenericResponse[common.EmoteHistoryEntry]{
+			Errors: &[]common.ErrorMessage{{Message: "Internal Server Error"}},
+		}, start)
+
+		return
+	}
+
+	ch, err := postgres.GetChannelByName(request.Context(), login, common.TWITCH)
+	if err != nil {
+		api.GenericResponse(writer, http.StatusNotFound, common.GenericResponse[common.EmoteHistoryEntry]{
+			Errors: &[]common.ErrorMessage{{Message: "Channel not found"}},
+		}, start)
+
+		return
+	}
+
+	limit := defaultEmoteLimit
+	if v := request.URL.Query().Get("limit"); v != "" {
+		if n, parseErr := strconv.Atoi(v); parseErr == nil && n > 0 && n <= maxEmoteLimit {
+			limit = n
+		}
+	}
+
+	entries, err := clickhouse.GetEmoteHistory(request.Context(), "", ch.ChannelID, limit)
+	if err != nil {
+		logger.Error.Printf("Error fetching emote history: %v", err)
+		api.GenericResponse(writer, http.StatusInternalServerError, common.GenericResponse[common.EmoteHistoryEntry]{
+			Errors: &[]common.ErrorMessage{{Message: "Failed to fetch emote history"}},
+		}, start)
+
+		return
+	}
+
+	if entries == nil {
+		entries = []common.EmoteHistoryEntry{}
+	}
+
+	api.GenericResponse(writer, http.StatusOK, common.GenericResponse[common.EmoteHistoryEntry]{
+		Data: &entries,
+	}, start)
+}
+
+func writeEmoteError(writer http.ResponseWriter, code int, start time.Time) {
+	api.GenericResponse(writer, code, common.EmoteStatsResponse{
+		Data:       &[]common.EmoteStat{},
+		StatusCode: code,
+		Duration:   time.Since(start).Seconds(),
+	}, start)
+}

--- a/common/config.go
+++ b/common/config.go
@@ -3,25 +3,105 @@ package common
 
 // Config holds the configuration for the application, including database and service settings.
 type Config struct {
-	Postgres   SQLConfig    `json:"postgres"`
-	Clickhouse SQLConfig    `json:"clickhouse"`
-	Twitch     TwitchConfig `json:"twitch"`
-	Redis      RedisConfig  `json:"redis"`
-	API        APIConfig    `json:"api"`
-	Socket     APIConfig    `json:"socket"`
-	Redirects  APIConfig    `json:"redirects"`
-	Uploader   APIConfig    `json:"uploader"`
-	Prometheus APIConfig    `json:"prometheus"`
-	Haste      HasteConfig  `json:"haste"`
-	Nats       BoolConfig   `json:"nats"`
-	Loops      BoolConfig   `json:"loops"`
+	Postgres   SQLConfig     `json:"postgres"`
+	Clickhouse SQLConfig     `json:"clickhouse"`
+	Twitch     TwitchConfig  `json:"twitch"`
+	Discord    DiscordConfig `json:"discord"`
+	Spotify    SpotifyConfig `json:"spotify"`
+	Kick       KickConfig    `json:"kick"`
+	Anilist    AnilistConfig `json:"anilist"`
+	Trakt      TraktConfig   `json:"trakt"`
+	FFZ        FFZConfig     `json:"ffz"`
+	STV        STVConfig     `json:"stv"`
+	BTTV       BTTVConfig    `json:"bttv"`
+	Misc       MiscConfig    `json:"misc"`
+	Redis      RedisConfig   `json:"redis"`
+	API        APIConfig     `json:"api"`
+	Socket     APIConfig     `json:"socket"`
+	Redirects  APIConfig     `json:"redirects"`
+	Uploader   APIConfig     `json:"uploader"`
+	Prometheus APIConfig     `json:"prometheus"`
+	Haste      HasteConfig   `json:"haste"`
+	Nats       BoolConfig    `json:"nats"`
+	Loops      BoolConfig    `json:"loops"`
 }
 
 // TwitchConfig holds the configuration for Twitch API integration.
 type TwitchConfig struct {
 	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
+	ClientSecret string `json:"client_secret"` //nolint:gosec
 	OauthURI     string `json:"oauth_uri"`
+}
+
+// DiscordConfig holds the configuration for Discord OAuth and bot integration.
+type DiscordConfig struct {
+	ID           string `json:"id"`
+	OAuth        string `json:"oauth"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"` //nolint:gosec
+	OAuthURI     string `json:"oauth_uri"`
+}
+
+// SpotifyConfig holds the configuration for Spotify OAuth integration.
+type SpotifyConfig struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"` //nolint:gosec
+	OAuthURI     string `json:"oauth_uri"`
+}
+
+// KickConfig holds the configuration for Kick OAuth integration (PKCE flow).
+type KickConfig struct {
+	ID           string `json:"id"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"` //nolint:gosec
+	OAuthURI     string `json:"oauth_uri"`
+	OAuth        string `json:"oauth"`
+}
+
+// AnilistConfig holds the configuration for AniList OAuth integration.
+type AnilistConfig struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"` //nolint:gosec
+	OAuthURI     string `json:"oauth_uri"`
+}
+
+// TraktConfig holds the configuration for Trakt OAuth integration.
+type TraktConfig struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"` //nolint:gosec
+	OAuthURI     string `json:"oauth_uri"`
+}
+
+// FFZConfig holds the configuration for FrankerFaceZ OAuth integration.
+type FFZConfig struct {
+	ID           string `json:"id"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"` //nolint:gosec
+	Token        string `json:"token"`
+	Refresh      string `json:"refresh"`
+	OAuthURI     string `json:"oauth_uri"`
+}
+
+// STVConfig holds the configuration for 7TV bot token.
+type STVConfig struct {
+	Token string `json:"token"`
+	ID    string `json:"id"`
+}
+
+// BTTVConfig holds the configuration for BTTV bot token.
+type BTTVConfig struct {
+	Token string `json:"token"`
+	ID    string `json:"id"`
+}
+
+// SteamConfig holds the Steam Web API key.
+type SteamConfig struct {
+	Key string `json:"key"`
+}
+
+// MiscConfig holds miscellaneous third-party service configurations.
+type MiscConfig struct {
+	Steam SteamConfig `json:"steam"`
 }
 
 // BoolConfig holds the configuration for the simple enablable service.
@@ -33,7 +113,7 @@ type BoolConfig struct {
 type APIConfig struct {
 	Host    string `json:"host"`
 	Port    string `json:"port"`
-	AuthKey string `json:"authkey,omitempty"`
+	AuthKey string `json:"authkey,omitempty"` //nolint:gosec
 	Enabled bool   `json:"enabled"`
 }
 
@@ -51,7 +131,7 @@ type SQLConfig struct {
 	Host     string `json:"host"`
 	Port     string `json:"port"`
 	User     string `json:"user"`
-	Password string `json:"password"`
+	Password string `json:"password"` //nolint:gosec
 	Database string `json:"database"`
 }
 

--- a/common/db/clickhouse.go
+++ b/common/db/clickhouse.go
@@ -2,7 +2,10 @@
 package db
 
 import (
+	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
@@ -44,4 +47,156 @@ func InitClickhouse(config common.Config) (*ClickhouseClient, error) {
 	}
 
 	return &ClickhouseClient{conn}, nil
+}
+
+// EmoteStatsOptions holds the query filters for GetEmoteStats.
+type EmoteStatsOptions struct {
+	// ChannelID filters results to a specific channel (uses emote_usage table when UserID is empty).
+	ChannelID string
+	// UserID filters results to a specific user (uses user_emote_usage table).
+	UserID string
+	// Order is "ASC" or "DESC".
+	Order string
+	// Providers is the normalised list of provider enum values (e.g. "STV", "FFZ"). Empty = all.
+	Providers []string
+	// PeriodHours is the time window in hours. 0 means no time filter ("all").
+	PeriodHours int
+	// Limit is the maximum number of rows to return.
+	Limit int
+	// Offset is the number of rows to skip (cursor-based pagination).
+	Offset int
+}
+
+// GetEmoteStats queries aggregated emote usage from Clickhouse with cursor-based pagination.
+func (db *ClickhouseClient) GetEmoteStats( //nolint:cyclop
+	ctx context.Context,
+	opts EmoteStatsOptions,
+) ([]common.EmoteStat, error) {
+	table := "potatbotat.emote_usage"
+	if opts.UserID != "" {
+		table = "potatbotat.user_emote_usage"
+	}
+
+	var sb strings.Builder
+	args := make([]any, 0, 8)
+
+	fmt.Fprintf(&sb,
+		"SELECT emote_id, emote_name, emote_alias, provider, sum(count) AS count FROM %s FINAL WHERE 1=1",
+		table,
+	)
+
+	if opts.ChannelID != "" {
+		args = append(args, opts.ChannelID)
+		fmt.Fprintf(&sb, " AND channel_id = $%d", len(args))
+	}
+
+	if opts.UserID != "" {
+		args = append(args, opts.UserID)
+		fmt.Fprintf(&sb, " AND user_id = $%d", len(args))
+	}
+
+	if opts.PeriodHours > 0 {
+		cutoff := time.Now().Add(-time.Duration(opts.PeriodHours) * time.Hour)
+		args = append(args, cutoff)
+		fmt.Fprintf(&sb, " AND used_at >= $%d", len(args))
+	}
+
+	if len(opts.Providers) > 0 {
+		placeholders := make([]string, len(opts.Providers))
+		for i, p := range opts.Providers {
+			args = append(args, p)
+			placeholders[i] = fmt.Sprintf("$%d", len(args))
+		}
+		fmt.Fprintf(&sb, " AND provider IN (%s)", strings.Join(placeholders, ","))
+	}
+
+	sb.WriteString(" GROUP BY emote_id, emote_name, emote_alias, provider")
+
+	order := "DESC"
+	if strings.EqualFold(opts.Order, "asc") {
+		order = "ASC"
+	}
+	fmt.Fprintf(&sb, " ORDER BY count %s", order)
+
+	limit := opts.Limit
+	if limit <= 0 || limit > 300 {
+		limit = 100
+	}
+	fmt.Fprintf(&sb, " LIMIT %d", limit)
+
+	if opts.Offset > 0 {
+		fmt.Fprintf(&sb, " OFFSET %d", opts.Offset)
+	}
+
+	rows, err := db.Query(ctx, sb.String(), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var stats []common.EmoteStat
+	for rows.Next() {
+		var s common.EmoteStat
+		if err := rows.Scan(&s.EmoteID, &s.EmoteName, &s.EmoteAlias, &s.Provider, &s.Count); err != nil {
+			return nil, err
+		}
+		stats = append(stats, s)
+	}
+
+	return stats, rows.Err()
+}
+
+// GetEmoteHistory queries the most recent per-user emote usage records from Clickhouse.
+func (db *ClickhouseClient) GetEmoteHistory(
+	ctx context.Context,
+	userID string,
+	channelID string,
+	limit int,
+) ([]common.EmoteHistoryEntry, error) {
+	if limit <= 0 || limit > 300 {
+		limit = 100
+	}
+
+	var sb strings.Builder
+	args := make([]any, 0, 3)
+
+	sb.WriteString(`
+		SELECT emote_id, emote_name, emote_alias, provider, channel_id, user_id, sum(count) AS count, max(used_at) AS used_at
+		FROM potatbotat.user_emote_usage FINAL
+		WHERE 1=1
+	`)
+
+	if userID != "" {
+		args = append(args, userID)
+		fmt.Fprintf(&sb, " AND user_id = $%d", len(args))
+	}
+
+	if channelID != "" {
+		args = append(args, channelID)
+		fmt.Fprintf(&sb, " AND channel_id = $%d", len(args))
+	}
+
+	sb.WriteString(" GROUP BY emote_id, emote_name, emote_alias, provider, channel_id, user_id")
+	sb.WriteString(" ORDER BY used_at DESC")
+	fmt.Fprintf(&sb, " LIMIT %d", limit)
+
+	rows, err := db.Query(ctx, sb.String(), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var entries []common.EmoteHistoryEntry
+	for rows.Next() {
+		var e common.EmoteHistoryEntry
+		if err := rows.Scan(
+			&e.EmoteID, &e.EmoteName, &e.EmoteAlias, &e.Provider,
+			&e.ChannelID, &e.UserID, &e.Count, &e.UsedAt,
+		); err != nil {
+			return nil, err
+		}
+		entries = append(entries, e)
+	}
+
+	return entries, rows.Err()
 }

--- a/common/db/postgres.go
+++ b/common/db/postgres.go
@@ -399,6 +399,8 @@ func (db *PostgresClient) getChannelByType( //nolint:cyclop
 				*channel.Blocks.Users = append(*channel.Blocks.Users, block)
 			case common.CommandBlock:
 				*channel.Blocks.Commands = append(*channel.Blocks.Commands, block)
+			case common.GlobalBlock:
+				// global blocks are not categorized into users/commands
 			}
 		}
 	} else {
@@ -723,4 +725,253 @@ func (db *PostgresClient) GetUploadCreatedAt(
 	}
 
 	return &createdAt, nil
+}
+
+// GetAllChannels retrieves all channels with state = 'JOINED', ordered by username.
+func (db *PostgresClient) GetAllChannels(ctx context.Context) ([]common.ChannelListItem, error) {
+	query := `
+		SELECT channel_id, username, platform, state
+		FROM channels
+		WHERE state = 'JOINED'
+		ORDER BY username
+	`
+
+	rows, err := db.Pool.Query(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var channels []common.ChannelListItem
+	for rows.Next() {
+		var ch common.ChannelListItem
+		if err := rows.Scan(&ch.ChannelID, &ch.Username, &ch.Platform, &ch.State); err != nil {
+			return nil, err
+		}
+		channels = append(channels, ch)
+	}
+
+	return channels, rows.Err()
+}
+
+// UpdateUserSettings replaces the settings JSONB column for a user.
+func (db *PostgresClient) UpdateUserSettings(ctx context.Context, userID int, settings common.UserSettings) error {
+	query := `UPDATE users SET settings = $1 WHERE user_id = $2`
+	_, err := db.Pool.Exec(ctx, query, settings, userID)
+
+	return err
+}
+
+// UpdateChannelSettings replaces the settings JSONB column for a channel.
+func (db *PostgresClient) UpdateChannelSettings(
+	ctx context.Context,
+	channelID string,
+	settings common.ChannelSettings,
+) error {
+	query := `UPDATE channels SET settings = $1 WHERE channel_id = $2`
+	_, err := db.Pool.Exec(ctx, query, settings, channelID)
+
+	return err
+}
+
+// GetCommandSettings retrieves all command settings rows for a given channel.
+func (db *PostgresClient) GetCommandSettings(
+	ctx context.Context,
+	channelID string,
+) ([]common.CommandSettings, error) {
+	query := `
+		SELECT
+			channel_id,
+			command,
+			permission,
+			users_blacklisted,
+			users_whitelisted,
+			custom_cooldown,
+			channel_usage,
+			is_enabled,
+			offline_only,
+			silent_errors,
+			allow_bots,
+			platform,
+			ambassador_granted
+		FROM command_settings
+		WHERE channel_id = $1
+		ORDER BY command
+	`
+
+	rows, err := db.Pool.Query(ctx, query, channelID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []common.CommandSettings
+	for rows.Next() {
+		var cs common.CommandSettings
+		if err := rows.Scan(
+			&cs.ChannelID,
+			&cs.Command,
+			&cs.Permission,
+			&cs.UsersBlacklisted,
+			&cs.UsersWhitelisted,
+			&cs.CustomCooldown,
+			&cs.ChannelUsage,
+			&cs.IsEnabled,
+			&cs.OfflineOnly,
+			&cs.SilentErrors,
+			&cs.AllowBots,
+			&cs.Platform,
+			&cs.AmbassadorGranted,
+		); err != nil {
+			return nil, err
+		}
+		results = append(results, cs)
+	}
+
+	return results, rows.Err()
+}
+
+// UpsertCommandSettings inserts or updates a single command's settings row.
+func (db *PostgresClient) UpsertCommandSettings(ctx context.Context, cs common.CommandSettings) error {
+	query := `
+		INSERT INTO command_settings (
+			channel_id, command, permission, users_blacklisted, users_whitelisted,
+			custom_cooldown, is_enabled, offline_only, silent_errors, allow_bots,
+			platform, ambassador_granted
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+		ON CONFLICT (channel_id, command) DO UPDATE SET
+			permission         = EXCLUDED.permission,
+			users_blacklisted  = EXCLUDED.users_blacklisted,
+			users_whitelisted  = EXCLUDED.users_whitelisted,
+			custom_cooldown    = EXCLUDED.custom_cooldown,
+			is_enabled         = EXCLUDED.is_enabled,
+			offline_only       = EXCLUDED.offline_only,
+			silent_errors      = EXCLUDED.silent_errors,
+			allow_bots         = EXCLUDED.allow_bots,
+			platform           = EXCLUDED.platform,
+			ambassador_granted = EXCLUDED.ambassador_granted
+	`
+
+	platform := cs.Platform
+	if platform == "" {
+		platform = "TWITCH"
+	}
+
+	_, err := db.Pool.Exec(
+		ctx, query,
+		cs.ChannelID, cs.Command, cs.Permission,
+		cs.UsersBlacklisted, cs.UsersWhitelisted,
+		cs.CustomCooldown, cs.IsEnabled, cs.OfflineOnly,
+		cs.SilentErrors, cs.AllowBots, platform, cs.AmbassadorGranted,
+	)
+
+	return err
+}
+
+// ResetCommandSettings resets a single command's overrides back to their defaults.
+func (db *PostgresClient) ResetCommandSettings(ctx context.Context, channelID, command string) error {
+	query := `
+		UPDATE command_settings SET
+			is_enabled         = TRUE,
+			offline_only       = NULL,
+			custom_cooldown    = NULL,
+			silent_errors      = FALSE,
+			users_whitelisted  = NULL,
+			users_blacklisted  = NULL,
+			allow_bots         = NULL
+		WHERE channel_id = $1 AND command = $2
+	`
+	_, err := db.Pool.Exec(ctx, query, channelID, command)
+
+	return err
+}
+
+// GetChannelAmbassadors returns the ambassadors slice for a channel, used for auth checks.
+func (db *PostgresClient) GetChannelAmbassadors(
+	ctx context.Context,
+	channelID string,
+	platform common.Platforms,
+) ([]string, error) {
+	query := `SELECT ambassadors FROM channels WHERE channel_id = $1 AND platform = $2`
+
+	var ambassadors []string
+	err := db.Pool.QueryRow(ctx, query, channelID, platform).Scan(&ambassadors)
+	if err != nil {
+		return nil, err
+	}
+
+	return ambassadors, nil
+}
+
+// GetUserReminders retrieves all pending reminders for a user on a given platform.
+func (db *PostgresClient) GetUserReminders(
+	ctx context.Context,
+	userID string,
+	platform common.Platforms,
+) ([]common.Reminder, error) {
+	query := `
+		SELECT
+			reminder_id, user_id, recipient_id, channel_id,
+			message, ready_at, set_at, afk_withheld, status, platform, sent_at, type
+		FROM reminders
+		WHERE recipient_id = $1 AND platform = $2
+		ORDER BY set_at DESC
+	`
+
+	rows, err := db.Pool.Query(ctx, query, userID, platform)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var reminders []common.Reminder
+	for rows.Next() {
+		var r common.Reminder
+		if err := rows.Scan(
+			&r.ReminderID, &r.UserID, &r.RecipientID, &r.ChannelID,
+			&r.Message, &r.ReadyAt, &r.SetAt, &r.AfkWithheld, &r.Status, &r.Platform, &r.SentAt, &r.Type,
+		); err != nil {
+			return nil, err
+		}
+		reminders = append(reminders, r)
+	}
+
+	return reminders, rows.Err()
+}
+
+// DeleteReminder hard-deletes a reminder by ID, verifying the owner platform ID.
+func (db *PostgresClient) DeleteReminder(ctx context.Context, reminderID int, recipientID string) error {
+	query := `DELETE FROM reminders WHERE reminder_id = $1 AND recipient_id = $2`
+	_, err := db.Pool.Exec(ctx, query, reminderID, recipientID)
+
+	return err
+}
+
+// UpsertOAuthToken stores or refreshes a platform OAuth token for a given user.
+func (db *PostgresClient) UpsertOAuthToken(
+	ctx context.Context,
+	platformID string,
+	platform common.Platforms,
+	accessToken string,
+	refreshToken string,
+	scope []string,
+	expiresIn int,
+) error {
+	query := `
+		INSERT INTO connection_oauth (
+			platform_id, access_token, refresh_token, scope, expires_in, added_at, platform
+		) VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (platform_id, platform) DO UPDATE SET
+			access_token  = EXCLUDED.access_token,
+			refresh_token = EXCLUDED.refresh_token,
+			scope         = EXCLUDED.scope,
+			expires_in    = EXCLUDED.expires_in,
+			added_at      = EXCLUDED.added_at
+	`
+	_, err := db.Pool.Exec(
+		ctx, query,
+		platformID, accessToken, refreshToken, scope, expiresIn, time.Now(), platform,
+	)
+
+	return err
 }

--- a/common/types.go
+++ b/common/types.go
@@ -15,6 +15,12 @@ const (
 	DISCORD Platforms = "DISCORD"
 	KICK    Platforms = "KICK"
 	STV     Platforms = "STV"
+	SPOTIFY Platforms = "SPOTIFY"
+	ANILIST Platforms = "ANILIST"
+	TRAKT   Platforms = "TRAKT"
+	FFZ     Platforms = "FFZ"
+	BTTV    Platforms = "BTTV"
+	STEAM   Platforms = "STEAM"
 )
 
 // PermissionLevel represents the permission level of a user interally with the api and bot.
@@ -147,36 +153,47 @@ type AddedByData struct {
 // ChannelSettings represents the settings for a channel, including bot settings, cooldowns, language,
 // permission levels, and other configurations.
 type ChannelSettings struct {
-	PajBot            *string  `json:"paj_bot,omitempty"`
-	UserCooldown      *int     `json:"user_cooldown,omitempty"`
-	ChannelCooldown   *int     `json:"channel_cooldown,omitempty"`
-	Language          string   `json:"language"`
-	Permission        string   `json:"permission"`
-	Prefix            string   `json:"prefix"`
-	UsersBlacklisted  []string `json:"users_blacklisted"`
-	NoReply           bool     `json:"no_reply"`
-	FirstMsgResponses bool     `json:"first_msg_responses"`
-	WhisperOnly       bool     `json:"whisper_only"`
-	OfflineOnly       bool     `json:"offline_only"`
-	ForceLanguage     bool     `json:"force_language"`
-	SilentErrors      bool     `json:"silent_errors"`
-	ColorResponses    bool     `json:"color_responses"`
+	PajBot                 *string  `json:"paj_bot,omitempty"`
+	UserCooldown           *int     `json:"user_cooldown,omitempty"`
+	ChannelCooldown        *int     `json:"channel_cooldown,omitempty"`
+	OnlinePermission       *string  `json:"online_permission,omitempty"`
+	EmoteStreakResponse    *string  `json:"emote_streak_response,omitempty"`
+	PyramidResponse        *string  `json:"pyramid_response,omitempty"`
+	OnlineSilentErrors     *bool    `json:"online_silent_errors,omitempty"`
+	OnlineWhisperOnly      *bool    `json:"online_whisper_only,omitempty"`
+	AllowBotEmoteTracking  *bool    `json:"allow_bot_emote_tracking,omitempty"`
+	IgnoreDropped          *bool    `json:"ignore_dropped,omitempty"`
+	NoLinks                *bool    `json:"no_links,omitempty"`
+	ForcePyramidNotVerbose *bool    `json:"force_potato_not_verbose,omitempty"`
+	Language               string   `json:"language"`
+	Permission             string   `json:"permission"`
+	Prefix                 string   `json:"prefix"`
+	UsersBlacklisted       []string `json:"users_blacklisted"`
+	NoReply                bool     `json:"no_reply"`
+	FirstMsgResponses      bool     `json:"first_msg_responses"`
+	WhisperOnly            bool     `json:"whisper_only"`
+	OfflineOnly            bool     `json:"offline_only"`
+	ForceLanguage          bool     `json:"force_language"`
+	SilentErrors           bool     `json:"silent_errors"`
+	ColorResponses         bool     `json:"color_responses"`
 }
 
 // CommandSettings represents the settings for a command in a channel, including its permissions, cooldowns,
 // and usage limits.
 type CommandSettings struct {
-	ChannelID        string   `json:"channel_id"`
-	Command          string   `json:"command"`
-	Permission       string   `json:"permission"`
-	UsersBlacklisted []string `json:"users_blacklisted"`
-	UsersWhitelisted []string `json:"users_whitelisted"`
-	CustomCooldown   int      `json:"custom_cooldown"`
-	ChannelUsage     int      `json:"channel_usage"`
-	IsEnabled        bool     `json:"is_enabled"`
-	OfflineOnly      bool     `json:"offline_only"`
-	SilentErrors     bool     `json:"silent_errors"`
-	AllowBots        bool     `json:"allow_bots"`
+	ChannelID         string   `json:"channel_id"`
+	Command           string   `json:"command"`
+	Permission        *string  `json:"permission,omitempty"`
+	UsersBlacklisted  []string `json:"users_blacklisted,omitempty"`
+	UsersWhitelisted  []string `json:"users_whitelisted,omitempty"`
+	CustomCooldown    *int     `json:"custom_cooldown,omitempty"`
+	ChannelUsage      int      `json:"channel_usage"`
+	IsEnabled         bool     `json:"is_enabled"`
+	OfflineOnly       *bool    `json:"offline_only,omitempty"`
+	SilentErrors      bool     `json:"silent_errors"`
+	AllowBots         *bool    `json:"allow_bots,omitempty"`
+	Platform          string   `json:"platform"`
+	AmbassadorGranted bool     `json:"ambassador_granted"`
 }
 
 // PlatformOauth represents the OAuth token and metadata for a user on a specific platform, including.
@@ -400,3 +417,62 @@ const (
 	BotVIP  BotCommandRequirements = "VIP"
 	BotMod  BotCommandRequirements = "MOD"
 )
+
+// ChannelListItem is a lightweight channel representation used for list endpoints (e.g. nav search).
+type ChannelListItem struct {
+	ChannelID string    `json:"channel_id"`
+	Username  string    `json:"username"`
+	Platform  Platforms `json:"platform"`
+	State     string    `json:"state"`
+}
+
+// EmoteStat represents an aggregated emote usage entry from Clickhouse.
+type EmoteStat struct {
+	EmoteID    string `json:"emote_id"`
+	EmoteName  string `json:"emote_name"`
+	EmoteAlias string `json:"emote_alias"`
+	Provider   string `json:"provider"`
+	Count      int64  `json:"count"`
+}
+
+// EmoteHistoryEntry represents a single per-user emote usage record from Clickhouse.
+type EmoteHistoryEntry struct {
+	EmoteID    string    `json:"emote_id"`
+	EmoteName  string    `json:"emote_name"`
+	EmoteAlias string    `json:"emote_alias"`
+	Provider   string    `json:"provider"`
+	ChannelID  string    `json:"channel_id"`
+	UserID     string    `json:"user_id"`
+	Count      int64     `json:"count"`
+	UsedAt     time.Time `json:"used_at"`
+}
+
+// PageInfo contains cursor-based pagination metadata.
+type PageInfo struct {
+	HasNextPage bool   `json:"hasNextPage"`
+	Cursor      string `json:"cursor"`
+}
+
+// EmoteStatsResponse is the paginated response shape for GET /emotes/stats.
+type EmoteStatsResponse struct {
+	Data       *[]EmoteStat `json:"data"`
+	Pagination PageInfo     `json:"pagination"`
+	StatusCode int          `json:"statusCode"`
+	Duration   float64      `json:"duration"`
+}
+
+// Reminder represents a scheduled or on-next-seen reminder message.
+type Reminder struct {
+	SetAt       time.Time  `json:"set_at"`
+	SentAt      *time.Time `json:"sent_at,omitempty"`
+	ReadyAt     *time.Time `json:"ready_at,omitempty"`
+	UserID      string     `json:"user_id"`
+	RecipientID string     `json:"recipient_id"`
+	ChannelID   string     `json:"channel_id"`
+	Message     string     `json:"message"`
+	Status      string     `json:"status"`
+	Platform    string     `json:"platform"`
+	Type        string     `json:"type"`
+	ReminderID  int        `json:"reminder_id"`
+	AfkWithheld bool       `json:"afk_withheld"`
+}

--- a/exampleconfig.json
+++ b/exampleconfig.json
@@ -4,6 +4,56 @@
     "client_secret": "asdf1234",
     "oauth_uri": "https://api.potat.industries"
   },
+  "discord": {
+    "id": "",
+    "oauth": "",
+    "client_id": "",
+    "client_secret": "",
+    "oauth_uri": "https://your-domain.com/"
+  },
+  "spotify": {
+    "client_id": "",
+    "client_secret": "",
+    "oauth_uri": "https://your-domain.com/"
+  },
+  "kick": {
+    "id": "",
+    "client_id": "",
+    "client_secret": "",
+    "oauth_uri": "https://your-domain.com/",
+    "oauth": ""
+  },
+  "anilist": {
+    "client_id": "",
+    "client_secret": "",
+    "oauth_uri": "https://your-domain.com/"
+  },
+  "trakt": {
+    "client_id": "",
+    "client_secret": "",
+    "oauth_uri": "https://your-domain.com/"
+  },
+  "ffz": {
+    "id": "",
+    "client_id": "",
+    "client_secret": "",
+    "token": "",
+    "refresh": "",
+    "oauth_uri": "https://your-domain.com/"
+  },
+  "stv": {
+    "token": "",
+    "id": ""
+  },
+  "bttv": {
+    "token": "",
+    "id": ""
+  },
+  "misc": {
+    "steam": {
+      "key": ""
+    }
+  },
   "loops": {
     "enabled": true
   },


### PR DESCRIPTION
- Add `GET /channels` returns all joined channels
- Add `GET /emotes/stats` emote usage stats with optional filters and pagination
- Add `GET /emotes/history/{login}` recent per user emote history for a channel
- Add `GET /channel/command-settings` fetch command settings for a channel
- Add `GetAllChannels`, `GetCommandSettings`, `GetChannelAmbassadors` Postgres methods
- Add `GetEmoteStats`, `GetEmoteHistory` Clickhouse methods